### PR TITLE
增加了调试信息分组的功能

### DIFF
--- a/debug.hpp
+++ b/debug.hpp
@@ -190,8 +190,19 @@
 #ifndef DEBUG_NAMESPACE_END
 # define DEBUG_NAMESPACE_END
 #endif
+#ifndef DEBUG_GROUP
+# define DEBUG_GROUP 0
+#endif
 #ifndef DEBUG_OUTPUT
-# define DEBUG_OUTPUT std::cerr <<
+# define DEBUG_OUTPUT(x) do { \
+    if (DEBUG_GROUP == 0) { \
+        std::cerr << x; \
+    } else { \
+        if (DEBUG_GROUP == group) { \
+            std::cerr << x; \
+        } \
+    } \
+} while (0)
 #endif
 #ifndef DEBUG_ENABLE_FILES_MATCH
 # define DEBUG_ENABLE_FILES_MATCH 0
@@ -1310,6 +1321,7 @@ private:
         panic = 2,
         supress = 3,
     } state;
+    int group;
 
     DEBUG_SOURCE_LOCATION loc;
 # if DEBUG_SHOW_TIMESTAMP == 2
@@ -1524,7 +1536,7 @@ private:
     }
 # endif
 public:
-    explicit debug(bool enable = true,
+    explicit debug(int group = 0, bool enable = true,
                    DEBUG_SOURCE_LOCATION const &loc =
                        DEBUG_SOURCE_LOCATION::current()) noexcept
         : state(enable
@@ -1533,7 +1545,8 @@ public:
 # endif
                     ? silent
                     : supress),
-          loc(loc) {
+          loc(loc),
+          group(group) {
     }
 
     debug &setloc(DEBUG_SOURCE_LOCATION const &newloc =
@@ -1971,7 +1984,7 @@ DEBUG_NAMESPACE_END
 DEBUG_NAMESPACE_BEGIN
 
 struct debug {
-    debug(bool = true, char const * = nullptr) noexcept {}
+    debug(int = 0, bool = true, char const * = nullptr) noexcept {}
 
     debug(debug &&) = delete;
     debug(debug const &) = delete;
@@ -2088,6 +2101,6 @@ DEBUG_NAMESPACE_END
 # undef debug
 #elif DEBUG_LEVEL
 # ifdef DEBUG_SOURCE_LOCATION_FAKER
-#  define debug() debug(true, DEBUG_SOURCE_LOCATION_FAKER)
+# define debug(...) debug(int(__VA_ARGS__), true, DEBUG_SOURCE_LOCATION_FAKER)
 # endif
 #endif

--- a/debug.hpp
+++ b/debug.hpp
@@ -190,17 +190,18 @@
 #ifndef DEBUG_NAMESPACE_END
 # define DEBUG_NAMESPACE_END
 #endif
+#ifndef DEBUG_OUTPUT
+# define DEBUG_OUTPUT std::cerr <<
+#endif
 #ifndef DEBUG_GROUP
 # define DEBUG_GROUP 0
 #endif
-#ifndef DEBUG_OUTPUT
-# define DEBUG_OUTPUT(x) do { \
+#ifndef DEBUG_OUTPUT_GROUP
+# define DEBUG_OUTPUT_GROUP(x) do { \
     if (DEBUG_GROUP == 0) { \
-        std::cerr << x; \
-    } else { \
-        if (DEBUG_GROUP == group) { \
-            std::cerr << x; \
-        } \
+        DEBUG_OUTPUT(x); \
+    } else if (group == DEBUG_GROUP) { \
+            DEBUG_OUTPUT(x); \
     } \
 } while (0)
 #endif
@@ -1616,7 +1617,7 @@ public:
                 throw std::runtime_error(oss.str());
 # elif DEBUG_PANIC_METHOD == 1
                 oss << '\n';
-                DEBUG_OUTPUT(oss.str());
+                DEBUG_OUTPUT_GROUP(oss.str());
 #  if defined(DEBUG_PANIC_CUSTOM_TRAP)
                 DEBUG_PANIC_CUSTOM_TRAP;
                 return;
@@ -1635,18 +1636,18 @@ public:
 #  endif
 # elif DEBUG_PANIC_METHOD == 2
                 oss << '\n';
-                DEBUG_OUTPUT(oss.str());
+                DEBUG_OUTPUT_GROUP(oss.str());
                 std::terminate();
 # else
                 oss << '\n';
-                DEBUG_OUTPUT(oss.str());
+                DEBUG_OUTPUT_GROUP(oss.str());
                 return;
 # endif
             }
         }
         if (state == print) {
             oss << '\n';
-            DEBUG_OUTPUT(oss.str());
+            DEBUG_OUTPUT_GROUP(oss.str());
         }
 # if DEBUG_STEPPING == 1
         static std::mutex mutex;

--- a/debug.hpp
+++ b/debug.hpp
@@ -201,7 +201,7 @@
     if (DEBUG_GROUP == 0) { \
         DEBUG_OUTPUT(x); \
     } else if (group == DEBUG_GROUP) { \
-            DEBUG_OUTPUT(x); \
+        DEBUG_OUTPUT(x); \
     } \
 } while (0)
 #endif


### PR DESCRIPTION
https://github.com/archibate/debug-hpp/issues/7
修改不影响现有功能

没有定义DEBUG_GROUP 则所有debug都有效
如果定义了DEBUG_GROUP ,则只有指定分组的debug会有效
示例代码
```

#define DEBUG_GROUP 2
#include "debug.hpp"
#include <iostream>
#include <vector>

int main(int argc, char **argv) {
  // 测试原始debug()功能
  debug(), "xxx", "hello";

  // 测试debug分组功能
  int my_var = 100;
  std::vector<int> my_vec = {10, 20, 30};

  debug(), "123", my_var;

  debug(1), "222", my_var;
  debug(1), "333", my_var;
  debug(2), "444", my_var;
  return 0;
}

```